### PR TITLE
Disambiguate trauma savant labels.

### DIFF
--- a/1.4/Defs/HediffDefs/Hediffs_Local_Group_TraumaSavant.xml
+++ b/1.4/Defs/HediffDefs/Hediffs_Local_Group_TraumaSavant.xml
@@ -34,8 +34,8 @@
 		<defName>TraumaSavant1</defName>
 		<hediffClass>HediffWithComps</hediffClass>
 		<scenarioCanAdd>true</scenarioCanAdd>
-		<label>trauma savant</label>
-		    <description>An exceptional condition caused by trauma to the brain. The brain, in the face of injury, has developed extreme abilities in some areas, while losing the ability to speak.</description>
+		<label>trauma savant (variant A)</label>
+		<description>An exceptional condition caused by trauma to the brain. The brain, in the face of injury, has developed extreme abilities in some areas, while losing the ability to speak.</description>
 		<stages>
 			<li>
 				<socialFightChanceFactor>0</socialFightChanceFactor>
@@ -64,8 +64,8 @@
 		<defName>TraumaSavant2</defName>
 		<hediffClass>HediffWithComps</hediffClass>
 		<scenarioCanAdd>true</scenarioCanAdd>
-		<label>trauma savant</label>
-		    <description>An exceptional condition caused by trauma to the brain. The brain, in the face of injury, has developed extreme abilities in some areas, while losing the ability to speak.</description>
+		<label>trauma savant (variant B)</label>
+		<description>An exceptional condition caused by trauma to the brain. The brain, in the face of injury, has developed extreme abilities in some areas, while losing the ability to speak.</description>
 		<stages>
 			<li>
 				<socialFightChanceFactor>0</socialFightChanceFactor>
@@ -93,8 +93,8 @@
 		<defName>TraumaSavant3</defName>
 		<hediffClass>HediffWithComps</hediffClass>
 		<scenarioCanAdd>true</scenarioCanAdd>
-		<label>trauma savant</label>
-		    <description>An exceptional condition caused by trauma to the brain. The brain, in the face of injury, has developed extreme abilities in some areas, while losing the ability to speak.</description>
+		<label>trauma savant (variant C)</label>
+		<description>An exceptional condition caused by trauma to the brain. The brain, in the face of injury, has developed extreme abilities in some areas, while losing the ability to speak.</description>
 		<stages>
 			<li>
 				<socialFightChanceFactor>0</socialFightChanceFactor>
@@ -122,8 +122,8 @@
 		<defName>TraumaSavant4</defName>
 		<hediffClass>HediffWithComps</hediffClass>
 		<scenarioCanAdd>true</scenarioCanAdd>
-		<label>trauma savant</label>
-		    <description>An exceptional condition caused by trauma to the brain. The brain, in the face of injury, has developed extreme abilities in some areas, while losing the ability to speak.</description>
+		<label>trauma savant (variant D)</label>
+		<description>An exceptional condition caused by trauma to the brain. The brain, in the face of injury, has developed extreme abilities in some areas, while losing the ability to speak.</description>
 		<stages>
 			<li>
 				<socialFightChanceFactor>0</socialFightChanceFactor>
@@ -151,8 +151,8 @@
 		<defName>TraumaSavant5</defName>
 		<hediffClass>HediffWithComps</hediffClass>
 		<scenarioCanAdd>true</scenarioCanAdd>
-		<label>trauma savant</label>
-		    <description>An exceptional condition caused by trauma to the brain. The brain, in the face of injury, has developed extreme abilities in some areas, while losing the ability to speak.</description>
+		<label>trauma savant (variant E)</label>
+		<description>An exceptional condition caused by trauma to the brain. The brain, in the face of injury, has developed extreme abilities in some areas, while losing the ability to speak.</description>
 		<stages>
 			<li>
 				<socialFightChanceFactor>0</socialFightChanceFactor>
@@ -179,8 +179,8 @@
 		<defName>TraumaSavant6</defName>
 		<hediffClass>HediffWithComps</hediffClass>
 		<scenarioCanAdd>true</scenarioCanAdd>
-		<label>trauma savant</label>
-		    <description>An exceptional condition caused by trauma to the brain. The brain, in the face of injury, has developed extreme abilities in some areas, while losing the ability to speak.</description>
+		<label>trauma savant (variant F)</label>
+		<description>An exceptional condition caused by trauma to the brain. The brain, in the face of injury, has developed extreme abilities in some areas, while losing the ability to speak.</description>
 		<stages>
 			<li>
 				<socialFightChanceFactor>0</socialFightChanceFactor>
@@ -210,8 +210,8 @@
 		<defName>TraumaSavant7</defName>
 		<hediffClass>HediffWithComps</hediffClass>
 		<scenarioCanAdd>true</scenarioCanAdd>
-		<label>trauma savant</label>
-		    <description>An exceptional condition caused by trauma to the brain. The brain, in the face of injury, has developed extreme abilities in some areas, while losing the ability to speak.</description>
+		<label>trauma savant (variant G)</label>
+		<description>An exceptional condition caused by trauma to the brain. The brain, in the face of injury, has developed extreme abilities in some areas, while losing the ability to speak.</description>
 		<stages>
 			<li>
 				<socialFightChanceFactor>0</socialFightChanceFactor>


### PR DESCRIPTION
This gives each of the new "variants" of trauma savant a unique suffix in their labels, so they can more easily be distinguished on a pawn's health tab, the hediff's info card, and in debug actions, such as selecting a hediff to give to a pawn (seeing a list of seven "Trauma savant" is not a good experience).

The player is already able to inspect the hediffs to determine how they affect the pawn, so indicating there are different variants does not give the player new information, aside from potentially telling them how many variants there are.