### PR TITLE
Make TraumaSavant6 less hungry, not more.

### DIFF
--- a/1.4/Defs/HediffDefs/Hediffs_Local_Group_TraumaSavant.xml
+++ b/1.4/Defs/HediffDefs/Hediffs_Local_Group_TraumaSavant.xml
@@ -201,7 +201,7 @@
 					</li>
 				</capMods>
 				<restFallFactor>0.2</restFallFactor>
-				<hungerRateFactorOffset>0.65</hungerRateFactorOffset>
+				<hungerRateFactor>0.65</hungerRateFactor>
 			</li>
 		</stages>
 	</HediffDef>


### PR DESCRIPTION
In each of the variants of trauma savant, aside from the speaking and talking penalty, the other changes are all [arguably] buffs to the pawn (less psychic sensitivity can go either way).

For TraumaSavant6, the pawn is given 50% more eating speed, which is a buff, but a pretty trivial one, but makes them need 65% more food, which is a pretty severe penalty. (It also needs a lot less sleep.)

This changes the hungerRateFactorOffset to a hungerRateFactor, so the pawn instead only requires 65% as much food (35% less).

One could argue a pawn spending much less time sleeping would work up more of an appetite, but this direct relationship is not really present anywhere else in RimWorld. A Circadian half-cycler, for example, has no effect on hunger rate, even though the pawn never needs to be in bed.

Conversely, beds themselves affect a pawn's hunger rate (via the BedHungerRateFactor Stat), so the pawn not spending time in bed would be (presumably) hungrier because of that. (Though, in vanilla, that is only utilized by the SleepAccelerator.)