### PR TITLE
Disambiguate encapsulated pathogens

### DIFF
--- a/1.4/Defs/HediffDefs/Hediffs_Local_Group_Parasites.xml
+++ b/1.4/Defs/HediffDefs/Hediffs_Local_Group_Parasites.xml
@@ -190,7 +190,7 @@
 
 	<HediffDef ParentName="DiseaseBase">
 		<defName>EncapsulatedMuscleParasites</defName>
-		<label>encapsulated pathogen</label>
+		<label>encapsulated pathogen (muscle parasites)</label>
 		<description>Carries the pathogen, which can cause the disease to break out at any time.</description>
 		<scenarioCanAdd>true</scenarioCanAdd>
 		<stages>

--- a/1.4/Defs/HediffDefs/Hediffs_Local_Group_Parasites.xml
+++ b/1.4/Defs/HediffDefs/Hediffs_Local_Group_Parasites.xml
@@ -192,6 +192,9 @@
 		<defName>EncapsulatedMuscleParasites</defName>
 		<label>encapsulated pathogen (muscle parasites)</label>
 		<description>Carries the pathogen, which can cause the disease to break out at any time.</description>
+                <descriptionHyperlinks>
+                  <HediffDef>MuscleParasites</HediffDef>
+                </descriptionHyperlinks>
 		<scenarioCanAdd>true</scenarioCanAdd>
 		<stages>
 			<li>

--- a/1.4/Defs/HediffDefs/Hediffs_Local_Malaria.xml
+++ b/1.4/Defs/HediffDefs/Hediffs_Local_Malaria.xml
@@ -196,7 +196,7 @@
 
 	<HediffDef ParentName="DiseaseBase">
 		<defName>EncapsulatedMalaria</defName>
-		<label>encapsulated pathogen</label>
+		<label>encapsulated pathogen (malaria)</label>
 		<description>Carries the pathogen, which can cause the disease to break out at any time.</description>
 		<scenarioCanAdd>true</scenarioCanAdd>
 		<stages>

--- a/1.4/Defs/HediffDefs/Hediffs_Local_Malaria.xml
+++ b/1.4/Defs/HediffDefs/Hediffs_Local_Malaria.xml
@@ -198,6 +198,9 @@
 		<defName>EncapsulatedMalaria</defName>
 		<label>encapsulated pathogen (malaria)</label>
 		<description>Carries the pathogen, which can cause the disease to break out at any time.</description>
+                <descriptionHyperlinks>
+                  <HediffDef>Malaria</HediffDef>
+                </descriptionHyperlinks>
 		<scenarioCanAdd>true</scenarioCanAdd>
 		<stages>
 			<li>

--- a/1.4/Defs/HediffDefs/Hediffs_Local_Plague.xml
+++ b/1.4/Defs/HediffDefs/Hediffs_Local_Plague.xml
@@ -323,7 +323,7 @@
 
 	<HediffDef ParentName="DiseaseBase">
 		<defName>EncapsulatedPlague</defName>
-		<label>encapsulated pathogen</label>
+		<label>encapsulated pathogen (plague)</label>
 		<description>Carries the pathogen, which can cause the disease to break out at any time.</description>
 		<stages>
 			<li>

--- a/1.4/Defs/HediffDefs/Hediffs_Local_Plague.xml
+++ b/1.4/Defs/HediffDefs/Hediffs_Local_Plague.xml
@@ -325,6 +325,10 @@
 		<defName>EncapsulatedPlague</defName>
 		<label>encapsulated pathogen (plague)</label>
 		<description>Carries the pathogen, which can cause the disease to break out at any time.</description>
+                <descriptionHyperlinks>
+                  <HediffDef>Plague</HediffDef>
+                  <HediffDef>BenignGrowth</HediffDef>
+                </descriptionHyperlinks>
 		<stages>
 			<li>
 				<partEfficiencyOffset>-0.1</partEfficiencyOffset>

--- a/1.4/Defs/HediffDefs/Hediffs_Local_Tuberculosis.xml
+++ b/1.4/Defs/HediffDefs/Hediffs_Local_Tuberculosis.xml
@@ -213,7 +213,7 @@
 
 	<HediffDef ParentName="DiseaseBase">
 		<defName>EncapsulatedTuberculosis</defName>
-		<label>encapsulated pathogen</label>
+		<label>encapsulated pathogen (tuberculosis)</label>
 		<description>Carries the pathogen, which can cause the disease to break out at any time.</description>
 		<stages>
 			<li>

--- a/1.4/Defs/HediffDefs/Hediffs_Local_Tuberculosis.xml
+++ b/1.4/Defs/HediffDefs/Hediffs_Local_Tuberculosis.xml
@@ -215,6 +215,9 @@
 		<defName>EncapsulatedTuberculosis</defName>
 		<label>encapsulated pathogen (tuberculosis)</label>
 		<description>Carries the pathogen, which can cause the disease to break out at any time.</description>
+                <descriptionHyperlinks>
+                  <HediffDef>Tuberculosis</HediffDef>
+                </descriptionHyperlinks>
 		<stages>
 			<li>
 				<partEfficiencyOffset>-0.1</partEfficiencyOffset>


### PR DESCRIPTION
Each of the different EncapsulatedX hediffs use the same label, "encapsulated pathogen". This means they all show up identically in a pawn's health tab, in the debug actions, etc.

This change gives them each a unique suffix that indicates which hediff is encapsulated.

While the player will know which hediff was encapsulated when one of their current pawns gains an EncapsulatedX hediff, theoretically, this can give the player more information about pawns who start with one of these hediffs. However, I do not think this "unearned" information outweighs the QoL improvement.

Particularly since, I imagine, the differences between the encapsulated pathogens are not severe enough to warrant any change in behavior by the player. (E.g., "Oh, that captured pawn has encapsulated malaria, so they're okay, but this one has encapsulated plague, so they're gonna be a hat.")

Also, now that the encapsulated pathogens have distinct identities, I've added description hyperlinks back to the relevant hediffs they cause.